### PR TITLE
Fix PUT via adding data and setting content type header

### DIFF
--- a/src/main/java/com/bandwidth/iris/sdk/IrisClient.java
+++ b/src/main/java/com/bandwidth/iris/sdk/IrisClient.java
@@ -109,6 +109,9 @@ public class IrisClient {
 
     public IrisResponse put(String uri, BaseModel data) throws Exception {
         HttpPut put = new HttpPut(uri);
+        StringEntity putBody = new StringEntity(XmlUtils.toXml(data));
+        put.addHeader("Content-Type", "application/xml");
+        put.setEntity(putBody);
         return executeRequest(put);
     }
 


### PR DESCRIPTION
I was trying to use `put` method in `IrisClient` and I got a response code of `Http 415`. When I checked the source code, I noticed content type in header is not set properly and even no data is being set. This PR fixes the issue, I confirmed.