### PR TITLE
Update LidbOrder.java

### DIFF
--- a/src/main/java/com/bandwidth/iris/sdk/model/LidbOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LidbOrder.java
@@ -45,9 +45,8 @@ public class LidbOrder extends BaseModel {
     }
 
     public static LidbOrder get(IrisClient client, String orderId) throws Exception {
-        LidbOrderResponse orderResponse = client.get(client.buildAccountModelUri(
-                new String[] { IrisPath.LIDB_ORDER_URI_PATH, orderId }), LidbOrderResponse.class);
-        LidbOrder order = orderResponse.getOrder();
+        LidbOrder order = client.get(client.buildAccountModelUri(
+                new String[] { IrisPath.LIDB_ORDER_URI_PATH, orderId }), LidbOrder.class);
         order.setClient(client);
         return order;
     }


### PR DESCRIPTION
The current file has a critical bug so that the function LidbOrder.get is not usable and gets a ClassCastException. This change fixes it.