### PR TITLE
Migrate the project to use the Jakarta API making it compatible with recent Java versions or newer framework versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.6</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
@@ -114,9 +114,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>1.47</version>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/A2pSettings.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/A2pSettings.java
@@ -1,7 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "A2pSettings")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ActivationStatus.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ActivationStatus.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/bandwidth/iris/sdk/model/ActivationStatusResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ActivationStatusResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ActivationStatusResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/AddedEmergencyNotificationGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/AddedEmergencyNotificationGroup.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "AddedEmergencyNotificationGroup")

--- a/src/main/java/com/bandwidth/iris/sdk/model/Address.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Address.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Address")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/AlternateEndUserIdentifier.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/AlternateEndUserIdentifier.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "AlternateEndUserIdentifier")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/AlternateEndUserIdentifierResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/AlternateEndUserIdentifierResponse.java
@@ -1,7 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "AlternateEndUserIdentifierResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/AlternateEndUserIdentifiersResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/AlternateEndUserIdentifiersResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "AlternateEndUserIdentifiersResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/AreaCodeSearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/AreaCodeSearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "AreaCodeSearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/AssignedNnRoute.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/AssignedNnRoute.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "AssignedNnRoute")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/AvailableNpaNxx.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/AvailableNpaNxx.java
@@ -5,10 +5,10 @@ import com.bandwidth.iris.sdk.IrisPath;
 import com.bandwidth.iris.sdk.IrisResponse;
 import com.bandwidth.iris.sdk.utils.XmlUtils;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/BaseOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/BaseOrderType.java
@@ -1,8 +1,8 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public abstract class BaseOrderType {

--- a/src/main/java/com/bandwidth/iris/sdk/model/BaseResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/BaseResponse.java
@@ -1,8 +1,8 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 public abstract class BaseResponse {

--- a/src/main/java/com/bandwidth/iris/sdk/model/BasicAuthentication.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/BasicAuthentication.java
@@ -1,10 +1,10 @@
 package com.bandwidth.iris.sdk.model;
 
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "BasicAuthentication")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/CallbackCredentials.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CallbackCredentials.java
@@ -2,10 +2,10 @@ package com.bandwidth.iris.sdk.model;
 
 
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "CallbackCredentials")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/CallbackSubscription.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CallbackSubscription.java
@@ -1,10 +1,10 @@
 package com.bandwidth.iris.sdk.model;
 
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "CallbackSubscription")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/CallingName.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CallingName.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "CallingName")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/City.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/City.java
@@ -3,10 +3,10 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/CityResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CityResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/CitySearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CitySearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "CitySearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/CombinedSearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CombinedSearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "CombinedSearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/CoveredRateCenter.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CoveredRateCenter.java
@@ -3,7 +3,7 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/bandwidth/iris/sdk/model/CoveredRateCenters.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CoveredRateCenters.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/Credentials.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Credentials.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Credentials")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/Csr.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Csr.java
@@ -4,10 +4,10 @@ import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 import com.bandwidth.iris.sdk.IrisResponse;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 
 @XmlRootElement(name="Csr")

--- a/src/main/java/com/bandwidth/iris/sdk/model/CsrData.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CsrData.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name="CsrData")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/CsrResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/CsrResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 @XmlRootElement(name="CsrResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/DeletedEmergencyNotificationGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/DeletedEmergencyNotificationGroup.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "DeletedEmergencyNotificationGroup")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/DisconnectTelephoneNumberOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/DisconnectTelephoneNumberOrder.java
@@ -3,10 +3,10 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "DisconnectTelephoneNumberOrder")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/DisconnectTelephoneNumberOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/DisconnectTelephoneNumberOrderResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/DisconnectTelephoneNumberOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/DisconnectTelephoneNumberOrderType.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/DldaOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/DldaOrder.java
@@ -4,7 +4,7 @@ import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 import com.bandwidth.iris.sdk.IrisResponse;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/bandwidth/iris/sdk/model/DldaOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/DldaOrderResponse.java
@@ -1,9 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "DldaOrderResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/DldaTnGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/DldaTnGroup.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/E911.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/E911.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "E911")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/EepToEngAssociations.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EepToEngAssociations.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "EepToEngAssociations")

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmailSubscription.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmailSubscription.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "EmailSubscription")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationCallback.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationCallback.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Callback")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationEndpointAssociation.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationEndpointAssociation.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationEndpointOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationEndpointOrder.java
@@ -1,7 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "EmergencyNotificationEndpointOrder")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationEndpointOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationEndpointOrderResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "EmergencyNotificationEndpointOrderResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroup.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "EmergencyNotificationGroup")

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroupOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroupOrder.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "EmergencyNotificationRecipientsResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroupOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroupOrderResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "EmergencyNotificationGroupOrderResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroupsResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationGroupsResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "EmergencyNotificationGroupsResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationRecipient.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationRecipient.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "EmergencyNotificationRecipient")

--- a/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationRecipientsResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/EmergencyNotificationRecipientsResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "EmergencyNotificationRecipientsResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/Error.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Error.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "Error")

--- a/src/main/java/com/bandwidth/iris/sdk/model/ErrorResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ErrorResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ErrorResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ExistingTelephoneNumberOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ExistingTelephoneNumberOrderType.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/Features.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Features.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Features")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/FileListResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/FileListResponse.java
@@ -1,9 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import com.bandwidth.iris.sdk.IrisClient;
-import com.bandwidth.iris.sdk.IrisPath;
-
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 
 @XmlRootElement(name="fileListResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/FileMetaData.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/FileMetaData.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "FileMetaData")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/FileUploadResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/FileUploadResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="fileUploadResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/Host.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Host.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Host")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ImportTnCheckerPayload.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ImportTnCheckerPayload.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/ImportTnCheckerResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ImportTnCheckerResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="ImportTnCheckerResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ImportTnError.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ImportTnError.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name="ImportTnError")

--- a/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrder.java
@@ -3,7 +3,7 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 import java.io.File;
 import java.util.List;

--- a/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrderSummary.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrderSummary.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 
 @XmlRootElement(name="ImportTnOrderSummary")

--- a/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrders.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrders.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 @XmlRootElement(name="ImportTnOrders")

--- a/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrdersResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ImportTnOrdersResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="ImportTnOrdersResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/IrisStatus.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/IrisStatus.java
@@ -1,8 +1,8 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "irisStatus")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/LATASearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LATASearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "LATASearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/LidbOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LidbOrder.java
@@ -4,7 +4,7 @@ import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 import com.bandwidth.iris.sdk.IrisResponse;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/bandwidth/iris/sdk/model/LidbOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LidbOrderResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "LidbOrderResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/LidbTnGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LidbTnGroup.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/LineOptionOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LineOptionOrder.java
@@ -3,10 +3,10 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/LineOptionOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LineOptionOrderResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "LineOptionOrderResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/LineOptions.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LineOptions.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/Links.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Links.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Links")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ListOrderIdUserIdDate.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ListOrderIdUserIdDate.java
@@ -1,8 +1,7 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 @XmlRootElement(name = "ListOrderIdUserIdDate")

--- a/src/main/java/com/bandwidth/iris/sdk/model/ListingName.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ListingName.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ListingName")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/LnpOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LnpOrder.java
@@ -3,7 +3,7 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;

--- a/src/main/java/com/bandwidth/iris/sdk/model/LnpOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LnpOrderResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/bandwidth/iris/sdk/model/LnpOrderSupp.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LnpOrderSupp.java
@@ -1,8 +1,8 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "LnpOrderSupp")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/LosingCarrierTnList.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/LosingCarrierTnList.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/MessagingSettings.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/MessagingSettings.java
@@ -1,7 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "MessagingSettings")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ModifiedEmergencyNotificationGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ModifiedEmergencyNotificationGroup.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "ModifiedEmergencyNotificationGroup")

--- a/src/main/java/com/bandwidth/iris/sdk/model/NPANXXSearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/NPANXXSearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "NPANXXSearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/Note.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Note.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
 @XmlRootElement(name = "Note")

--- a/src/main/java/com/bandwidth/iris/sdk/model/Notes.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Notes.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/NumberPortabilityRequest.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/NumberPortabilityRequest.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/NumberPortabilityResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/NumberPortabilityResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/Order.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Order.java
@@ -3,10 +3,10 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
 @XmlRootElement(name = "Order")

--- a/src/main/java/com/bandwidth/iris/sdk/model/OrderHistory.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/OrderHistory.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 
 @XmlRootElement(name="OrderHistory")

--- a/src/main/java/com/bandwidth/iris/sdk/model/OrderHistoryWrapper.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/OrderHistoryWrapper.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 @XmlRootElement(name="OrderHistoryWrapper")

--- a/src/main/java/com/bandwidth/iris/sdk/model/OrderIdUserIdDate.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/OrderIdUserIdDate.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
 @XmlRootElement(name = "OrderIdUserIdDate")

--- a/src/main/java/com/bandwidth/iris/sdk/model/OrderRequest.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/OrderRequest.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
 @XmlRootElement(name = "orderRequest")

--- a/src/main/java/com/bandwidth/iris/sdk/model/OrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/OrderResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/bandwidth/iris/sdk/model/RateCenter.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RateCenter.java
@@ -3,10 +3,10 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/RateCenterGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RateCenterGroup.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/RateCenterResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RateCenterResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/RateCenterSearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RateCenterSearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "RateCenterSearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrder.java
@@ -3,7 +3,7 @@ package com.bandwidth.iris.sdk.model;
 import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrderResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="RemoveImportedTnOrdersResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrderSummary.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrderSummary.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name="RemoveImportedTnOrderSummary")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrders.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/RemoveImportedTnOrders.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 @XmlRootElement(name="RemoveImportedTnOrders")

--- a/src/main/java/com/bandwidth/iris/sdk/model/Reservation.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Reservation.java
@@ -7,10 +7,10 @@ import com.bandwidth.iris.sdk.utils.XmlUtils;
 
 import org.apache.http.HttpStatus;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/ReservationResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ReservationResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ReservationResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ResponseSelectWrapper.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ResponseSelectWrapper.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ResponseSelectWrapper")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ResponseStatus.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ResponseStatus.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ResponseStatus")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SearchResult.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SearchResult.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/SearchResultForAvailableNpaNxx.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SearchResultForAvailableNpaNxx.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/ServiceAddress.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ServiceAddress.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ServiceAddress")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeer.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeer.java
@@ -4,7 +4,7 @@ import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 import com.bandwidth.iris.sdk.IrisResponse;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerMessagingApplicationsSettings.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerMessagingApplicationsSettings.java
@@ -1,7 +1,7 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "ApplicationSettings")
 public class SipPeerMessagingApplicationsSettings extends BaseModel {

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerMmsFeature.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerMmsFeature.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "MmsFeature")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "SipPeerResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerSmsFeature.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerSmsFeature.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "SipPeerSmsFeature")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumber.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumber.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "SipPeerTelephoneNumber")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumberResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumberResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "SipPeerTelephoneNumberResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumbers.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumbers.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumbersResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeerTelephoneNumbersResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/Site.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Site.java
@@ -4,10 +4,10 @@ import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 import com.bandwidth.iris.sdk.IrisResponse;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 @XmlRootElement(name = "Site")

--- a/src/main/java/com/bandwidth/iris/sdk/model/SiteResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SiteResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "SiteResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/SitesResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SitesResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/StateSearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/StateSearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "StateSearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/Status.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Status.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Status")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/Subscriber.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Subscriber.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "Subscriber")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/Subscription.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Subscription.java
@@ -4,10 +4,10 @@ import com.bandwidth.iris.sdk.IrisClient;
 import com.bandwidth.iris.sdk.IrisPath;
 import com.bandwidth.iris.sdk.IrisResponse;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/SubscriptionsResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SubscriptionsResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/TNSipPeersResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TNSipPeersResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/TNss.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TNss.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumber.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumber.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 import java.util.Date;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumberDetail.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumberDetail.java
@@ -1,9 +1,8 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "TelephoneNumberDetail")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumberDetails.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumberDetails.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumberResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumberResponse.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Date;
 
 @XmlRootElement(name = "TelephoneNumberResponse")

--- a/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumbersResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TelephoneNumbersResponse.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/bandwidth/iris/sdk/model/TerminationHost.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TerminationHost.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "TerminationHost")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/TnLineOptions.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TnLineOptions.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Created by sbarstow on 6/16/15.

--- a/src/main/java/com/bandwidth/iris/sdk/model/TnOptionGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TnOptionGroup.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "TnOptionGroup")

--- a/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrder.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrder.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "TnOptionOrder")

--- a/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrderResponse.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrderResponse.java
@@ -1,7 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "TnOptionOrderResponse")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrderSummary.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrderSummary.java
@@ -1,7 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "TnOptionOrderSummary")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrders.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TnOptionOrders.java
@@ -1,6 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
 @XmlRootElement(name = "TnOptionOrders")

--- a/src/main/java/com/bandwidth/iris/sdk/model/TollFreeVanitySearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TollFreeVanitySearchAndOrderType.java
@@ -1,7 +1,7 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "TollFreeVanitySearchAndOrderType")
 public class TollFreeVanitySearchAndOrderType extends BaseOrderType {

--- a/src/main/java/com/bandwidth/iris/sdk/model/TollFreeWildCharSearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/TollFreeWildCharSearchAndOrderType.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "TollFreeWildCharSearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/UpdatedEmergencyNotificationGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/UpdatedEmergencyNotificationGroup.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "UpdatedEmergencyNotificationGroup")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/VoiceHostGroup.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/VoiceHostGroup.java
@@ -1,8 +1,8 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "VoiceHostGroup")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/Warning.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/Warning.java
@@ -1,7 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "Warning")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/WirelessInfo.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/WirelessInfo.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "WirelessInfo")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/model/ZIPSearchAndOrderType.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/ZIPSearchAndOrderType.java
@@ -1,8 +1,6 @@
 package com.bandwidth.iris.sdk.model;
 
-import javax.xml.bind.annotation.*;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.xml.bind.annotation.*;
 
 @XmlRootElement(name = "ZIPSearchAndOrderType")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/java/com/bandwidth/iris/sdk/utils/XmlUtils.java
+++ b/src/main/java/com/bandwidth/iris/sdk/utils/XmlUtils.java
@@ -1,9 +1,9 @@
 package com.bandwidth.iris.sdk.utils;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;

--- a/src/test/java/com/bandwidth/iris/sdk/SiteTests.java
+++ b/src/test/java/com/bandwidth/iris/sdk/SiteTests.java
@@ -55,7 +55,7 @@ public class SiteTests extends BaseModelTests {
                         .withStatus(200)
                         .withBody(IrisClientTestUtils.validSiteResponseXml)));
 
-        Site s = Site.get(getDefaultClient(), "1234");
+        Site s = Site.get(getDefaultClient(), "2858");
         s.delete();
 
         expectedEx.expect(IrisClientException.class);


### PR DESCRIPTION
We've noticed that the main SDK has compatibility with more recent Java versions or frameworks, however the iris SDK is using the older jaxb API. While the java migration is not required (I tested at least compatibility with Java 17 and seems to be working just fine), I assume the API can safely be migrated to the newer Jakarta API packages & runtimes.

There was one test that was failing after the migration and I also had to upgrade the wiremock API as it was causing some class cast exceptions (again due to it using jaxb/javax in the older versions).

Please let me know if there's anything else I need to test and/or change in order to cotribute the changes.