### PR TITLE
Ensure siteId of SipPeers are set on list

### DIFF
--- a/src/main/java/com/bandwidth/iris/sdk/model/SipPeer.java
+++ b/src/main/java/com/bandwidth/iris/sdk/model/SipPeer.java
@@ -78,6 +78,7 @@ public class SipPeer extends BaseModel {
         sipPeers = tnSipPeersResponse.getSipPeers();
         for (SipPeer peer : sipPeers) {
             peer.setClient(client);
+            peer.setSiteId(siteId);
         }
         return sipPeers;
     }


### PR DESCRIPTION
`SipPeer` `get` method is properly setting both `siteId` and `client`; but `list` is only setting `client`. If you happen to call `delete` for a s`SipPeer` retrieved via `list`, the `delete` endpoint url is not properly created due to missing `siteId` attribute. This PR fixes that.